### PR TITLE
Download databus-metric-catalog-sink jar from Nexus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG STREAM_REACTOR_VERSION=0.2.5
 RUN curl -sk -SL https://github.com/datamountaineer/stream-reactor/releases/download/v${STREAM_REACTOR_VERSION}/kafka-connect-cassandra-${STREAM_REACTOR_VERSION}-${STREAM_REACTOR_CASSANDRA_VERSION}-all.tar.gz \
     | tar -xzf - -C /usr/share/java/kafka/ kafka-connect-cassandra-${STREAM_REACTOR_VERSION}-${STREAM_REACTOR_CASSANDRA_VERSION}-all.jar
 
-ARG DATABUS_METRIC_CATALOG_SINK_VERSION=0.1.2
-RUN curl -sk -SL  http://zenpip.zenoss.eng/packages/databus-metric-catalog-sink-${DATABUS_METRIC_CATALOG_SINK_VERSION}-zapp.tar.gz \
+ARG NEXUS_RELEASE_URL=http://nexus.zenoss.eng:8081/nexus/content/repositories/releases
+ARG DATABUS_METRIC_CATALOG_SINK_VERSION=0.2.0
+RUN curl -sk -SL ${NEXUS_RELEASE_URL}/org/zenoss/databus/databus-metric-catalog-sink/${DATABUS_METRIC_CATALOG_SINK_VERSION}/databus-metric-catalog-sink-${DATABUS_METRIC_CATALOG_SINK_VERSION}-zapp.tar.gz \
     | tar --strip-components=2 -xzf - -C /usr/share/java/kafka lib/databus-metric-catalog-sink/databus-metric-catalog-sink-${DATABUS_METRIC_CATALOG_SINK_VERSION}.jar


### PR DESCRIPTION
The updated build process does not push artifacts to zenpip. Instead, we can download direct from nexus.  Version 0.2.0 is the latest released copy of databus-metric-catalog-sink built on jenkins.zing.zenoss.eng.